### PR TITLE
Rename reducerPath to reducerKey for clarity

### DIFF
--- a/examples/posts-and-counter/src/app/services/counter.ts
+++ b/examples/posts-and-counter/src/app/services/counter.ts
@@ -5,7 +5,7 @@ interface CountResponse {
 }
 
 export const counterApi = createApi({
-  reducerPath: 'counterApi',
+  reducerKey: 'counterApi',
   baseQuery: fetchBaseQuery(),
   entityTypes: ['Counter'],
   endpoints: (build) => ({

--- a/examples/posts-and-counter/src/app/services/posts.ts
+++ b/examples/posts-and-counter/src/app/services/posts.ts
@@ -8,7 +8,7 @@ export interface Post {
 type PostsResponse = Post[];
 
 export const postApi = createApi({
-  reducerPath: 'postsApi',
+  reducerKey: 'postsApi',
   baseQuery: fetchBaseQuery(),
   entityTypes: ['Posts'],
   endpoints: (build) => ({

--- a/examples/posts-and-counter/src/app/services/times.ts
+++ b/examples/posts-and-counter/src/app/services/times.ts
@@ -5,7 +5,7 @@ interface TimeResponse {
 }
 
 export const timeApi = createApi({
-  reducerPath: 'timeApi',
+  reducerKey: 'timeApi',
   baseQuery: fetchBaseQuery(),
   entityTypes: ['Time'],
   endpoints: (build) => ({

--- a/examples/posts-and-counter/src/app/store.ts
+++ b/examples/posts-and-counter/src/app/store.ts
@@ -7,9 +7,9 @@ import { timeApi } from './services/times';
 export const createStore = (options?: ConfigureStoreOptions['preloadedState'] | undefined) =>
   configureStore({
     reducer: {
-      [counterApi.reducerPath]: counterApi.reducer,
-      [postApi.reducerPath]: postApi.reducer,
-      [timeApi.reducerPath]: timeApi.reducer,
+      [counterApi.reducerKey]: counterApi.reducer,
+      [postApi.reducerKey]: postApi.reducer,
+      [timeApi.reducerKey]: timeApi.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(counterApi.middleware, postApi.middleware, timeApi.middleware),

--- a/examples/svelte-counter/src/services/counter.ts
+++ b/examples/svelte-counter/src/services/counter.ts
@@ -5,7 +5,7 @@ interface CountResponse {
 }
 
 export const counterApi = createApi({
-    reducerPath: 'counterApi',
+    reducerKey: 'counterApi',
     baseQuery: fetchBaseQuery(),
     entityTypes: ['Counter'],
     endpoints: (build) => ({

--- a/src/apiState.ts
+++ b/src/apiState.ts
@@ -106,19 +106,19 @@ export type MutationState<D extends EndpointDefinitions> = {
   [requestId: string]: MutationSubState<D[string]> | undefined;
 };
 
-const __phantomType_ReducerPath = Symbol();
+const __phantomType_ReducerKey = Symbol();
 export interface QueryStatePhantomType<Identifier extends string> {
-  [__phantomType_ReducerPath]: Identifier;
+  [__phantomType_ReducerKey]: Identifier;
 }
 
 export type RootState<
   Definitions extends EndpointDefinitions,
   EntityTypes extends string,
-  ReducerPath extends string
+  ReducerKey extends string
 > = {
-  [P in ReducerPath]: CombinedState<Definitions, EntityTypes> & QueryStatePhantomType<P>;
+  [P in ReducerKey]: CombinedState<Definitions, EntityTypes> & QueryStatePhantomType<P>;
 };
 
-export type InternalRootState<ReducerPath extends string> = {
-  [_ in ReducerPath]: CombinedState<any, string>;
+export type InternalRootState<ReducerKey extends string> = {
+  [_ in ReducerKey]: CombinedState<any, string>;
 };

--- a/src/buildMiddleware.ts
+++ b/src/buildMiddleware.ts
@@ -10,27 +10,27 @@ const batch = typeof reactBatch !== 'undefined' ? reactBatch : (fn: Function) =>
 type QueryStateMeta<T> = Record<string, undefined | T>;
 type TimeoutId = ReturnType<typeof setTimeout>;
 
-export function buildMiddleware<Definitions extends EndpointDefinitions, ReducerPath extends string>({
-  reducerPath,
+export function buildMiddleware<Definitions extends EndpointDefinitions, ReducerKey extends string>({
+  reducerKey,
   endpointDefinitions,
   queryThunk,
   mutationThunk,
   keepUnusedDataFor,
   sliceActions: { removeQueryResult, unsubscribeQueryResult, updateSubscriptionOptions },
 }: {
-  reducerPath: ReducerPath;
+  reducerKey: ReducerKey;
   endpointDefinitions: EndpointDefinitions;
   queryThunk: AsyncThunk<unknown, QueryThunkArg<any>, {}>;
   mutationThunk: AsyncThunk<unknown, MutationThunkArg<any>, {}>;
   sliceActions: SliceActions;
   keepUnusedDataFor: number;
 }) {
-  type Api = MiddlewareAPI<ThunkDispatch<any, any, AnyAction>, RootState<Definitions, string, ReducerPath>>;
+  type Api = MiddlewareAPI<ThunkDispatch<any, any, AnyAction>, RootState<Definitions, string, ReducerKey>>;
 
   const currentRemovalTimeouts: QueryStateMeta<TimeoutId> = {};
 
   const currentPolls: QueryStateMeta<{ nextPollTimestamp: number; timeout?: TimeoutId; pollingInterval: number }> = {};
-  const middleware: Middleware<{}, RootState<Definitions, string, ReducerPath>, ThunkDispatch<any, any, AnyAction>> = (
+  const middleware: Middleware<{}, RootState<Definitions, string, ReducerKey>, ThunkDispatch<any, any, AnyAction>> = (
     api
   ) => (next) => (action) => {
     const result = next(action);
@@ -66,7 +66,7 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   return { middleware };
 
   function invalidateEntities(entities: readonly FullEntityDescription<string>[], api: Api) {
-    const state = api.getState()[reducerPath];
+    const state = api.getState()[reducerKey];
 
     const toInvalidate = new Set<QueryCacheKey>();
     for (const entity of entities) {
@@ -123,8 +123,8 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   }
 
   function startNextPoll({ queryCacheKey }: QuerySubstateIdentifier, api: Api) {
-    const querySubState = api.getState()[reducerPath].queries[queryCacheKey];
-    const subscriptions = api.getState()[reducerPath].subscriptions[queryCacheKey];
+    const querySubState = api.getState()[reducerKey].queries[queryCacheKey];
+    const subscriptions = api.getState()[reducerKey].subscriptions[queryCacheKey];
 
     if (!querySubState || querySubState.status === QueryStatus.uninitialized) return;
 
@@ -159,8 +159,8 @@ export function buildMiddleware<Definitions extends EndpointDefinitions, Reducer
   }
 
   function updatePollingInterval({ queryCacheKey }: QuerySubstateIdentifier, api: Api) {
-    const querySubState = api.getState()[reducerPath].queries[queryCacheKey];
-    const subscriptions = api.getState()[reducerPath].subscriptions[queryCacheKey];
+    const querySubState = api.getState()[reducerKey].queries[queryCacheKey];
+    const subscriptions = api.getState()[reducerKey].subscriptions[queryCacheKey];
 
     if (!querySubState || querySubState.status === QueryStatus.uninitialized) {
       return;

--- a/src/buildSelectors.ts
+++ b/src/buildSelectors.ts
@@ -42,22 +42,22 @@ const defaultMutationSubState = createNextState(
   }
 );
 
-export function buildSelectors<InternalQueryArgs, Definitions extends EndpointDefinitions, ReducerPath extends string>({
+export function buildSelectors<InternalQueryArgs, Definitions extends EndpointDefinitions, ReducerKey extends string>({
   serializeQueryArgs,
   endpointDefinitions,
-  reducerPath,
+  reducerKey,
 }: {
   serializeQueryArgs: InternalSerializeQueryArgs<InternalQueryArgs>;
   endpointDefinitions: Definitions;
-  reducerPath: ReducerPath;
+  reducerKey: ReducerKey;
 }) {
-  type RootState = _RootState<Definitions, string, ReducerPath>;
+  type RootState = _RootState<Definitions, string, ReducerKey>;
   const querySelectors = Object.entries(endpointDefinitions).reduce((acc, [name, endpoint]) => {
     if (isQueryDefinition(endpoint)) {
       acc[name] = (arg?) => (rootState) =>
         (arg === skipSelector
           ? undefined
-          : (rootState[reducerPath] as InternalState).queries[serializeQueryArgs(endpoint.query(arg), name)]) ??
+          : (rootState[reducerKey] as InternalState).queries[serializeQueryArgs(endpoint.query(arg), name)]) ??
         defaultQuerySubState;
     }
     return acc;
@@ -69,7 +69,7 @@ export function buildSelectors<InternalQueryArgs, Definitions extends EndpointDe
   const mutationSelectors = Object.entries(endpointDefinitions).reduce((acc, [name, endpoint]) => {
     if (isMutationDefinition(endpoint)) {
       acc[name] = (mutationId: string | typeof skipSelector) => (rootState) =>
-        (mutationId === skipSelector ? undefined : rootState[reducerPath].mutations[mutationId]) ??
+        (mutationId === skipSelector ? undefined : rootState[reducerKey].mutations[mutationId]) ??
         defaultMutationSubState;
     }
     return acc;

--- a/src/buildSlice.ts
+++ b/src/buildSlice.ts
@@ -41,18 +41,18 @@ function updateMutationSubstateIfExists(
 }
 
 export function buildSlice({
-  reducerPath,
+  reducerKey,
   queryThunk,
   mutationThunk,
   endpointDefinitions: definitions,
 }: {
-  reducerPath: string;
+  reducerKey: string;
   queryThunk: AsyncThunk<unknown, QueryThunkArg<any>, {}>;
   mutationThunk: AsyncThunk<unknown, MutationThunkArg<any>, {}>;
   endpointDefinitions: EndpointDefinitions;
 }) {
   const querySlice = createSlice({
-    name: `${reducerPath}/queries`,
+    name: `${reducerKey}/queries`,
     initialState: {} as QueryState<any>,
     reducers: {
       removeQueryResult(draft, { payload: { queryCacheKey } }: PayloadAction<QuerySubstateIdentifier>) {
@@ -98,7 +98,7 @@ export function buildSlice({
     },
   });
   const mutationSlice = createSlice({
-    name: `${reducerPath}/mutations`,
+    name: `${reducerKey}/mutations`,
     initialState: {} as MutationState<any>,
     reducers: {
       unsubscribeResult(draft, action: PayloadAction<MutationSubstateIdentifier>) {
@@ -138,7 +138,7 @@ export function buildSlice({
   });
 
   const invalidationSlice = createSlice({
-    name: `${reducerPath}/invalidation`,
+    name: `${reducerKey}/invalidation`,
     initialState: {} as InvalidationState<string>,
     reducers: {},
     extraReducers(builder) {
@@ -168,7 +168,7 @@ export function buildSlice({
   });
 
   const subscriptionSlice = createSlice({
-    name: `${reducerPath}/subscriptions`,
+    name: `${reducerKey}/subscriptions`,
     initialState: {} as SubscriptionState,
     reducers: {
       updateSubscriptionOptions(

--- a/src/buildThunks.ts
+++ b/src/buildThunks.ts
@@ -25,21 +25,21 @@ function defaultPostProcess(baseQueryReturnValue: unknown) {
   return baseQueryReturnValue;
 }
 
-export function buildThunks<InternalQueryArgs, ReducerPath extends string>({
-  reducerPath,
+export function buildThunks<InternalQueryArgs, ReducerKey extends string>({
+  reducerKey,
   baseQuery,
   endpointDefinitions,
 }: {
   baseQuery(args: InternalQueryArgs, api: QueryApi): any;
-  reducerPath: ReducerPath;
+  reducerKey: ReducerKey;
   endpointDefinitions: EndpointDefinitions;
 }) {
   const queryThunk = createAsyncThunk<
     unknown,
     QueryThunkArg<InternalQueryArgs>,
-    { state: InternalRootState<ReducerPath> }
+    { state: InternalRootState<ReducerKey> }
   >(
-    `${reducerPath}/executeQuery`,
+    `${reducerKey}/executeQuery`,
     (arg, { signal, rejectWithValue }) => {
       return baseQuery(arg.internalQueryArgs, { signal, rejectWithValue }).then(
         endpointDefinitions[arg.endpoint].postProcess ?? defaultPostProcess
@@ -47,7 +47,7 @@ export function buildThunks<InternalQueryArgs, ReducerPath extends string>({
     },
     {
       condition(arg, { getState }) {
-        let requestState = getState()[reducerPath]?.queries?.[arg.queryCacheKey];
+        let requestState = getState()[reducerKey]?.queries?.[arg.queryCacheKey];
         return !(requestState?.status === 'pending' || (requestState?.status === 'fulfilled' && !arg.forceRefetch));
       },
       dispatchConditionRejection: true,
@@ -57,8 +57,8 @@ export function buildThunks<InternalQueryArgs, ReducerPath extends string>({
   const mutationThunk = createAsyncThunk<
     unknown,
     MutationThunkArg<InternalQueryArgs>,
-    { state: InternalRootState<ReducerPath> }
-  >(`${reducerPath}/executeMutation`, (arg, { signal, rejectWithValue }) => {
+    { state: InternalRootState<ReducerKey> }
+  >(`${reducerKey}/executeMutation`, (arg, { signal, rejectWithValue }) => {
     return baseQuery(arg.internalQueryArgs, { signal, rejectWithValue }).then(
       endpointDefinitions[arg.endpoint].postProcess ?? defaultPostProcess
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,18 +24,18 @@ function defaultSerializeQueryArgs(args: any, endpoint: string) {
 export function createApi<
   InternalQueryArgs,
   Definitions extends EndpointDefinitions,
-  ReducerPath extends string,
+  ReducerKey extends string,
   EntityTypes extends string
 >({
   baseQuery,
-  reducerPath,
+  reducerKey,
   serializeQueryArgs: _serializeQueryArgs = defaultSerializeQueryArgs,
   endpoints,
   keepUnusedDataFor = 60,
 }: {
   baseQuery(args: InternalQueryArgs, api: QueryApi): any;
   entityTypes: readonly EntityTypes[];
-  reducerPath: ReducerPath;
+  reducerKey: ReducerKey;
   serializeQueryArgs?: SerializeQueryArgs<InternalQueryArgs>;
   endpoints(build: EndpointBuilder<InternalQueryArgs, EntityTypes>): Definitions;
   keepUnusedDataFor?: number;
@@ -49,21 +49,21 @@ export function createApi<
     mutation: (x) => ({ ...x, type: DefinitionType.mutation }),
   });
 
-  const { queryThunk, mutationThunk } = buildThunks({ baseQuery, reducerPath, endpointDefinitions });
+  const { queryThunk, mutationThunk } = buildThunks({ baseQuery, reducerKey, endpointDefinitions });
 
   const { reducer: _reducer, actions: sliceActions } = buildSlice({
     endpointDefinitions,
     queryThunk,
     mutationThunk,
-    reducerPath,
+    reducerKey,
   });
 
-  const reducer = (_reducer as any) as Reducer<State & QueryStatePhantomType<ReducerPath>, AnyAction>;
+  const reducer = (_reducer as any) as Reducer<State & QueryStatePhantomType<ReducerKey>, AnyAction>;
 
   const { querySelectors, mutationSelectors } = buildSelectors({
     serializeQueryArgs,
     endpointDefinitions,
-    reducerPath,
+    reducerKey,
   });
 
   const { mutationActions, queryActions } = buildActionMaps({
@@ -77,7 +77,7 @@ export function createApi<
   });
 
   const { middleware } = buildMiddleware({
-    reducerPath,
+    reducerKey,
     endpointDefinitions,
     queryThunk,
     mutationThunk,
@@ -94,7 +94,7 @@ export function createApi<
   });
 
   return {
-    reducerPath,
+    reducerKey,
     queryActions,
     mutationActions,
     reducer,

--- a/test/example.test.tsx
+++ b/test/example.test.tsx
@@ -18,7 +18,7 @@ describe('examples', () => {
   }
 
   const api = createApi({
-    reducerPath: 'api',
+    reducerKey: 'api',
     baseQuery({ url, method = 'GET', body }: QueryArg) {
       /*
           return fetch(`https://example.com/${url}`, {


### PR DESCRIPTION
- Renames `reducerPath` to `reducerKey` for clarity
- Don't mind the README changes - I'm just going to tackle all of those once `flatten_state` is merged in when I do the examples.

I still think we should consider renaming `reducerKey` to `name` on the public-facing `createApi`. I don't think a consumer really needs to know it's an internal reducer key, but open to either way :)